### PR TITLE
fix subscirbe error

### DIFF
--- a/root/usr/share/vssr/subscribe.lua
+++ b/root/usr/share/vssr/subscribe.lua
@@ -264,7 +264,11 @@ local function processData(szType, content)
         result.alias = '[' .. content.airport .. '] ' .. content.remarks
     end
     if not result.alias then
-        result.alias = result.server .. ':' .. result.server_port
+        if result.server and result.server_port then
+            result.alias = result.server .. ':' .. result.server_port
+        else
+            result.alias = "NULL"
+        end
     end
     -- alias 不参与 hashkey 计算
     local alias = result.alias


### PR DESCRIPTION
fix https://github.com/jerrykuku/luci-app-vssr/issues/70

一个兜底的fix
实质上造成这个异常的原因是订阅链接本身有问题，但是如果有机场就喜欢往订阅链接里塞垃圾信息的话，在这里抛出异常会直接中止掉订阅进程~~万一这个订阅链接里真有节点呢？~~