### PR TITLE
feat: 增加对 hysteria 协议节点支持

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Trojan \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Xray_plugin \
-	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server
+	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server \
+	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
 	
 LUCI_TITLE:=A New SS/SSR/Xray/Trojan LuCI interface
 LUCI_PKGARCH:=all
@@ -20,7 +21,8 @@ LUCI_DEPENDS:=+ipset +ip-full +iptables-mod-tproxy +dnsmasq-full +coreutils +cor
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Trojan:ipt2socks \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun:kcptun-client \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray_plugin:xray-plugin \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server:shadowsocksr-libev-ssr-server
+	+PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server:shadowsocksr-libev-ssr-server \
+	+PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria:hysteria
 
 define Package/$(PKG_NAME)/config
 config PACKAGE_$(PKG_NAME)_INCLUDE_Xray
@@ -41,6 +43,10 @@ config PACKAGE_$(PKG_NAME)_INCLUDE_Xray_plugin
 	
 config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server
 	bool "Include ShadowsocksR Libev Server"
+	default y if i386||x86_64||arm||aarch64
+
+config PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
+	bool "Include Hysteria"
 	default y if i386||x86_64||arm||aarch64
 endef
 

--- a/luasrc/model/cbi/vssr/client-config.lua
+++ b/luasrc/model/cbi/vssr/client-config.lua
@@ -139,6 +139,10 @@ if nixio.fs.access('/usr/sbin/trojan') then
     o:value('trojan', translate('Trojan'))
 end
 
+if nixio.fs.access('/usr/bin/hysteria') then
+    o:value('hysteria', translate('Hysteria'))
+end
+
 o.description = translate('Using incorrect encryption mothod may causes service fail to start')
 
 o = s:option(Value, 'alias', translate('Alias(optional)'))
@@ -154,6 +158,8 @@ o.rmempty = false
 o = s:option(Value, 'server_port', translate('Server Port'))
 o.datatype = 'port'
 o.rmempty = false
+
+o:depends('type', 'hysteria')
 
 o = s:option(Value, 'password', translate('Password'))
 o.password = true
@@ -180,6 +186,37 @@ for _, v in ipairs(encrypt_methods_ss) do
 end
 o.rmempty = true
 o:depends('type', 'ss')
+
+-- o:depends("type", "hysteria")
+o = s:option(Value, 'h_obfs', translate('Hysteria Obfs'))
+o.datatype = "minlength(1)"
+o.rmempty = false
+o:depends('type', 'hysteria')
+
+-- 协议
+o = s:option(ListValue, 'h_protocol', translate('Protocol'))
+o:value('udp', 'UDP')
+o:value('wechat-video', 'Wechat Video')
+o:value('faketcp', 'Fake TCP')
+o.rmempty = false
+o:depends('type', 'hysteria')
+
+-- up_mbps
+o = s:option(Value, 'h_up_mbps', translate('Up Mbps'))
+o.datatype = "uinteger"
+o.rmempty = false
+o:depends('type', 'hysteria')
+
+-- down_mbps
+o = s:option(Value, 'h_down_mbps', translate('Down Mbps'))
+o.datatype = "uinteger"
+o.rmempty = false
+o:depends('type', 'hysteria')
+
+o = s:option(Value, 'h_server_name', translate('Server Name'))
+o.datatype = 'host'
+o.rmempty = true
+o:depends('type', 'hysteria')
 
 -- Shadowsocks Plugin
 o = s:option(Value, 'plugin', translate('Plugin'))
@@ -381,6 +418,7 @@ o:depends('type', 'v2ray')
 o:depends('type', 'trojan')
 o:depends('type', 'vless')
 o:depends('type', 'xray')
+o:depends('type', 'hysteria')
 
 -- [[ TLS ]]--
 o = s:option(Flag, 'tls', translate('TLS'))

--- a/luasrc/model/cbi/vssr/client-config.lua
+++ b/luasrc/model/cbi/vssr/client-config.lua
@@ -159,8 +159,6 @@ o = s:option(Value, 'server_port', translate('Server Port'))
 o.datatype = 'port'
 o.rmempty = false
 
-o:depends('type', 'hysteria')
-
 o = s:option(Value, 'password', translate('Password'))
 o.password = true
 o.rmempty = true

--- a/root/etc/init.d/vssr
+++ b/root/etc/init.d/vssr
@@ -90,6 +90,7 @@ find_bin() {
     ssr-server) ret="ssr-server" ;;
     v2ray | vless) ret="xray" ;;
     trojan) ret="trojan" ;;
+    hysteria) ret="hysteria" ;;
     esac
     echo $(find /usr -perm /+x -type f -name $ret)
 }
@@ -365,6 +366,9 @@ start_shunt() {
             trojan)
                 $bin --config $config_file >/dev/null 2>&1 &
                 ;;
+            hysteria)
+                $bin -c $config_file >/dev/null 2>&1 &
+                ;;
             esac
             echo "$(date "+%Y-%m-%d %H:%M:%S") ${shunt_type}: $server_type 分流服务已启动!" >>/tmp/vssr.log
         fi
@@ -424,6 +428,10 @@ start_redir() {
             $sscmd -config $last_config_file >/dev/null 2>&1 &
             echo "$(date "+%Y-%m-%d %H:%M:%S") $($sscmd -version | head -1) 已启动!" >>/tmp/vssr.log
             ;;
+        hysteria)
+            $sscmd -c $last_config_file >/dev/null 2>&1 &
+            echo "$(date "+%Y-%m-%d %H:%M:%S") $($sscmd -v | head -1) 已启动!" >>/tmp/vssr.log
+            ;;
         trojan)
             for i in $(seq 1 $threads); do
                 $sscmd -c $last_config_file >/dev/null 2>&1 &
@@ -465,6 +473,10 @@ start_redir() {
         v2ray | vless)
             $ucmd -config $last_config_file >/dev/null 2>&1 &
             echo "$(date "+%Y-%m-%d %H:%M:%S") UDP TPROXY Relay: $($sscmd -version | head -1) 已启动!" >>/tmp/vssr.log
+            ;;
+        hysteria)
+            $ucmd -c $last_config_file >/dev/null 2>&1 &
+            echo "$(date "+%Y-%m-%d %H:%M:%S") UDP TPROXY Relay: $($sscmd -v | head -1) 已启动!" >>/tmp/vssr.log
             ;;
         trojan)
             $ucmd --config $last_config_file >/dev/null 2>&1 &
@@ -688,7 +700,7 @@ stop() {
     if [ $(uci_get_by_type global monitor_enable) = 1 ]; then
         kill -9 $(busybox ps -w | grep vssr-monitor | grep -v grep | awk '{print $1}') >/dev/null 2>&1
     fi
-    killall -q -9 ss-redir ss-local obfs-local ssr-redir ssr-local ssr-server xray-plugin xray trojan microsocks ipt2socks dns2socks pdnsd
+    killall -q -9 ss-redir ss-local obfs-local ssr-redir ssr-local ssr-server xray-plugin xray hysteria trojan microsocks ipt2socks dns2socks pdnsd
 
     if [ -f "/tmp/dnsmasq.d/dnsmasq-ssr.conf" ]; then
         rm -rf /tmp/dnsmasq.d/dnsmasq-ssr.conf /tmp/dnsmasq.ssr /tmp/dnsmasq.oversea

--- a/root/usr/share/vssr/genconfig_hysteria.lua
+++ b/root/usr/share/vssr/genconfig_hysteria.lua
@@ -1,0 +1,33 @@
+local ucursor = require 'luci.model.uci'.cursor()
+local json = require 'luci.jsonc'
+local server_section = arg[1]
+local proto = arg[2]
+local local_port = arg[3]
+local server = ucursor:get_all('vssr', server_section)
+
+local hysteria = {
+    server = server.server .. ":" .. tonumber(server.server_port),
+    obfs = server.h_obfs,
+    up_mbps = tonumber(server.h_up_mbps),
+    down_mbps = tonumber(server.h_down_mbps),
+    insecure = (server.insecure == '1') and true or false,
+    retry = 3,
+}
+
+if server.h_server_name ~= nil then
+    hysteria["server_name"] = tostring(server.h_server_name)
+end
+
+if proto == "tcp" then
+    hysteria["redirect_tcp"] = {
+        listen = ":" .. local_port,
+        timeout = 300
+    }
+else
+    hysteria["tproxy_udp"] = {
+        listen = ":" .. local_port,
+        timeout = 60
+    }
+end
+
+print(json.stringify(hysteria, 1))

--- a/root/usr/share/vssr/genconfig_hysteria.lua
+++ b/root/usr/share/vssr/genconfig_hysteria.lua
@@ -12,6 +12,7 @@ local hysteria = {
     down_mbps = tonumber(server.h_down_mbps),
     insecure = (server.insecure == '1') and true or false,
     retry = 3,
+    protocol = tostring(server.h_protocol),
 }
 
 if server.h_server_name ~= nil then


### PR DESCRIPTION
## 需要注意的一些地方：  

- 编译过程中，最好将 feeds hellowrold库依赖排在 passwall之前，passwall  hysteria 目前暂无增加 tcp redir；此问题感谢前辈的帮助： https://github.com/fw876/helloworld/commit/dfd9a805c4f7b04bd4fd46bf60770e88072a1025  
- hysteria 目前quic握手似乎存在一些问题，握手可能失败；调试方法：进入 ssh 执行：`/usr/bin/hysteria -c /var/etc/vssr_t.json`，然后根据 https://github.com/HyNetwork/hysteria/wiki/%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98 进行排错。