### PR TITLE
cleanup makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,43 +11,47 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Xray_plugin \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
-	
+
 LUCI_TITLE:=A New SS/SSR/Xray/Trojan LuCI interface
 LUCI_PKGARCH:=all
 LUCI_DEPENDS:=+ipset +ip-full +iptables-mod-tproxy +dnsmasq-full +coreutils +coreutils-base64 +bash +pdnsd-alt +wget-ssl +lua +luasocket +lua-maxminddb +lua-cjson \
-	+shadowsocks-libev-ss-local +shadowsocks-libev-ss-redir +shadowsocksr-libev-ssr-local +shadowsocksr-libev-ssr-redir +shadowsocksr-libev-ssr-check +simple-obfs \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray:xray-core \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Trojan:trojan \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Trojan:ipt2socks \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun:kcptun-client \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray_plugin:xray-plugin \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server:shadowsocksr-libev-ssr-server \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria:hysteria
+	+shadowsocks-libev-ss-local +shadowsocks-libev-ss-redir +shadowsocksr-libev-ssr-local +shadowsocksr-libev-ssr-redir +shadowsocksr-libev-ssr-check +simple-obfs
 
 define Package/$(PKG_NAME)/config
-config PACKAGE_$(PKG_NAME)_INCLUDE_Xray
-	bool "Include Xray"
-	default y if i386||x86_64||arm||aarch64
+	if PACKAGE_$(PKG_NAME)
+		menu "VSSR Configuration"
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Xray
+				bool "Include Xray"
+				select PACKAGE_xray-core
+				default y if i386||x86_64||arm||aarch64
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Trojan
-	bool "Include Trojan"
-	default y if i386||x86_64||arm||aarch64
-	
-config PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun
-	bool "Include Kcptun"
-	default n
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Trojan
+				bool "Include Trojan"
+				select PACKAGE_ipt2socks
+				select PACKAGE_trojan
+				default y if i386||x86_64||arm||aarch64
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Xray_plugin
-	bool "Include Shadowsocks Xray Plugin"
-	default y if i386||x86_64||arm||aarch64
-	
-config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server
-	bool "Include ShadowsocksR Libev Server"
-	default y if i386||x86_64||arm||aarch64
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun
+				bool "Include Kcptun"
+				select PACKAGE_kcptun-client
+				default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
-	bool "Include Hysteria"
-	default y if i386||x86_64||arm||aarch64
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Xray_plugin
+				bool "Include Shadowsocks Xray Plugin"
+				select PACKAGE_xray-plugin
+				default y if i386||x86_64||arm||aarch64
+
+			config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server
+				bool "Include ShadowsocksR Libev Server"
+				select PACKAGE_shadowsocksr-libev-ssr-server
+				default y if i386||x86_64||arm||aarch64
+
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
+				bool "Include Hysteria"
+				select PACKAGE_hysteria
+				default y if i386||x86_64||arm||aarch64
+		endmenu
+	endif
 endef
 
 define Package/$(PKG_NAME)/conffiles


### PR DESCRIPTION
因为Makefile中的`define Package/$(PKG_NAME)/config`部分没有加条件判断，对部分`PACKAGE_$(PKG_NAME)_INCLUDE_xxx`类包设置了`default y`，使得编译openwrt时即使不选择luci-app-vssr，部分`PACKAGE_$(PKG_NAME)_INCLUDE_xxx`也会被默认选中。例如对x64设备，即使不选中luci-app-vssr，trojan、hysteria等组件也会因luci-app-vssr的Makefile而被默认编译上。

这一PR使`luci-app-ssr_INCLUDE_xxx`类包只有在luci-app-vssr被选中后才能被配置，不选择luci-app-vssr则不会被默认安装，选中luci-app-vssr后仍能默认安装trojan, hysteria等组件。

我已在passwall的repo中提交了类似PR xiaorouji/openwrt-passwall#2118