### PR TITLE
dnsmasq.ssr moved to dnsmasq config dir

### DIFF
--- a/root/etc/init.d/vssr
+++ b/root/etc/init.d/vssr
@@ -621,26 +621,26 @@ start() {
     fi
     if rules; then
         if start_redir; then
-            if [ -f "/tmp/dnsmasq.ssr" ]; then
-                rm -rf /tmp/dnsmasq.ssr
+            if [ -f "/tmp/dnsmasq.d/dnsmasq.ssr.d" ]; then
+                rm -rf /tmp/dnsmasq.d/dnsmasq.ssr.d
             fi
             if [ -f "/tmp/dnsmasq.oversea" ]; then
                 rm -rf /tmp/dnsmasq.oversea
             fi
             mkdir -p /tmp/dnsmasq.d
             if [ "$run_mode" = "direct" ]; then
-                mkdir -p /tmp/dnsmasq.ssr
-                cp -rf /etc/vssr/ad.conf /tmp/dnsmasq.ssr/
+                mkdir -p /tmp/dnsmasq.d/dnsmasq.ssr.d
+                cp -rf /etc/vssr/ad.conf /tmp/dnsmasq.d/dnsmasq.ssr.d/
                 cat >/tmp/dnsmasq.d/dnsmasq-ssr.conf <<EOF
-conf-dir=/tmp/dnsmasq.ssr
+conf-dir=/tmp/dnsmasq.d/dnsmasq.ssr.d
 EOF
             elif ! [ "$run_mode" = "oversea" ]; then
-                mkdir -p /tmp/dnsmasq.ssr
-                cp -rf /etc/vssr/gfw_list.conf /tmp/dnsmasq.ssr/
-                cp -rf /etc/vssr/gfw_base.conf /tmp/dnsmasq.ssr/
-                cp -rf /etc/vssr/ad.conf /tmp/dnsmasq.ssr/
+                mkdir -p /tmp/dnsmasq.d/dnsmasq.ssr.d
+                cp -rf /etc/vssr/gfw_list.conf /tmp/dnsmasq.d/dnsmasq.ssr.d/
+                cp -rf /etc/vssr/gfw_base.conf /tmp/dnsmasq.d/dnsmasq.ssr.d/
+                cp -rf /etc/vssr/ad.conf /tmp/dnsmasq.d/dnsmasq.ssr.d/
                 cat >/tmp/dnsmasq.d/dnsmasq-ssr.conf <<EOF
-conf-dir=/tmp/dnsmasq.ssr
+conf-dir=/tmp/dnsmasq.d/dnsmasq.ssr.d
 EOF
             else
                 mkdir -p /tmp/dnsmasq.oversea
@@ -650,7 +650,7 @@ conf-dir=/tmp/dnsmasq.oversea
 EOF
             fi
             if [ $(uci_get_by_type global adblock) = 0 ]; then
-                rm -f /tmp/dnsmasq.ssr/ad.conf
+                rm -f /tmp/dnsmasq.d/dnsmasq.ssr.d/ad.conf
             fi
             /usr/share/vssr/gfw2ipset.sh
         else
@@ -703,7 +703,7 @@ stop() {
     killall -q -9 ss-redir ss-local obfs-local ssr-redir ssr-local ssr-server xray-plugin xray hysteria trojan microsocks ipt2socks dns2socks pdnsd
 
     if [ -f "/tmp/dnsmasq.d/dnsmasq-ssr.conf" ]; then
-        rm -rf /tmp/dnsmasq.d/dnsmasq-ssr.conf /tmp/dnsmasq.ssr /tmp/dnsmasq.oversea
+        rm -rf /tmp/dnsmasq.d/dnsmasq-ssr.conf /tmp/dnsmasq.d/dnsmasq.ssr.d /tmp/dnsmasq.oversea
         /etc/init.d/dnsmasq restart >/dev/null 2>&1
     fi
     del_cron

--- a/root/usr/share/vssr/gfw2ipset.sh
+++ b/root/usr/share/vssr/gfw2ipset.sh
@@ -8,35 +8,35 @@ uci_get_by_type() {
 v2ray_flow=$(uci_get_by_type global v2ray_flow)
 run_mode=$(uci_get_by_type global run_mode)
 
-mkdir -p /tmp/dnsmasq.ssr
+mkdir -p /tmp/dnsmasq.d/dnsmasq.ssr.d
 if ! [ "$run_mode" = "direct" ]; then
-    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"gfwlist"'\n",$0)}' /etc/vssr/gfw.list >/tmp/dnsmasq.ssr/custom_forward.conf
-    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/gfw.list >>/tmp/dnsmasq.ssr/custom_forward.conf
+    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"gfwlist"'\n",$0)}' /etc/vssr/gfw.list >/tmp/dnsmasq.d/dnsmasq.ssr.d/custom_forward.conf
+    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/gfw.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/custom_forward.conf
 fi
 
-awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/black.list >/tmp/dnsmasq.ssr/blacklist_forward.conf
-awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/black.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
-awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"whitelist"'\n",$0)}' /etc/vssr/white.list >/tmp/dnsmasq.ssr/whitelist_forward.conf
+awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/black.list >/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
+awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/black.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
+awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"whitelist"'\n",$0)}' /etc/vssr/white.list >/tmp/dnsmasq.d/dnsmasq.ssr.d/whitelist_forward.conf
 
 if [ "$v2ray_flow" = "1" ]; then
 
-    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/tw_video_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
-    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/tw_video_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/tw_video_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/tw_video_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
     
-    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/netflix_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
-    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/netflix_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/netflix_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/netflix_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
     
-    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/disney_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
-    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/disney_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/disney_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/disney_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
     
-    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/prime_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
-    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/prime_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/prime_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/prime_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
     
-    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/tvb_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
-    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/tvb_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/tvb_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/tvb_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
     
-    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/custom_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
-    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/custom_domain.list >>/tmp/dnsmasq.ssr/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"blacklist"'\n",$0)}' /etc/vssr/custom_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
+    awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/vssr/custom_domain.list >>/tmp/dnsmasq.d/dnsmasq.ssr.d/blacklist_forward.conf
 fi
 
 function valid_ip() {
@@ -62,7 +62,7 @@ function addWhiteList() {
   if valid_ip $host; then
     ipset -! add whitelist $host
   else
-    [ ! -z "$host" ] && echo "ipset=/.$host/whitelist" >>/tmp/dnsmasq.ssr/whitelist_forward.conf
+    [ ! -z "$host" ] && echo "ipset=/.$host/whitelist" >>/tmp/dnsmasq.d/dnsmasq.ssr.d/whitelist_forward.conf
   fi
 }
 


### PR DESCRIPTION
- fix jerrykuku/luci-app-vssr#305
- when dnsmasq started with ujail, only files in mounted folders could be loaded by dnsmasq. so we have to put the configuration files into $dnsmasqconfdir, which is /tmp/dnsmasq.d.