### PR TITLE
支持IPv6节点DNS解析

### DIFF
--- a/root/etc/init.d/vssr
+++ b/root/etc/init.d/vssr
@@ -192,6 +192,8 @@ start_rules() {
         server=$(ping ${server} -s 1 -c 1 | grep PING | cut -d'(' -f 2 | cut -d')' -f1)
         if echo $server | grep -E "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" >/dev/null; then
             echo $server >/etc/ssr_ip
+        elif [ "$server" != "${server#*:[0-9a-fA-F]}" ]; then
+            echo $server >/etc/ssr_ip
         else
             server=$(cat /etc/ssr_ip)
         fi
@@ -220,6 +222,8 @@ start_rules() {
         else
             udp_server=$(ping ${udp_server} -s 1 -c 1 | grep PING | cut -d'(' -f 2 | cut -d')' -f1)
             if echo $udp_server | grep -E "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" >/dev/null; then
+                echo $udp_server >/etc/ssr_ip
+            elif [ "$udp_server" != "${udp_server#*:[0-9a-fA-F]}" ]; then
                 echo $udp_server >/etc/ssr_ip
             else
                 udp_server=$(cat /etc/ssr_ip)


### PR DESCRIPTION
如果节点地址是域名，且有IPv6记录（AAAA），则vssr会丢弃解析结果，使用上一次的解析记录，这会导致非预期的行为（使用当前节点的设置连接上一个节点的IP）。
尤其对于新安装的环境，解析IP失败就直接导致vssr不能启动（找不到 /etc/ssr_ip ）。
因此提交此PR修复这个问题，解析出IPv6地址也认为有效，写入 /etc/ssr_ip 之中。